### PR TITLE
Add support for commands with hyphens in their name

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,12 +22,37 @@ export function activate(context: vscode.ExtensionContext) {
   );
 }
 
+/**
+ * This is the default word RegExp as defined here https://github.com/microsoft/vscode/blob/89e4d3eddcf035fa1a7b24ecebd3f32e48bd4697/src/vs/editor/common/model/wordHelper.ts#L15
+ * but with the hyphen character removed from the separators. This way, the hyphen is considered part of the word.
+ */
+const defaultWordRegExpWithoutHyphenSeparator = /(-?\d*\.\d\w*)|([^\`\~\!\@\#\$\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g;
+
+/**
+ * These languages all use the default word pattern, which has a hyphen character as a separator. This causes hyphens to be considered not part of the word.
+ * Currently, all the languages this extension supports except for Powershell use the default word pattern.
+ * The Powershell extension provides its own word pattern which does not have the hyphen character as a separator.
+ * See https://github.com/PowerShell/vscode-powershell/blob/fcc13c17bfedd500b155cccda1865f1bac63f545/src/main.ts#L76
+ */
+const languagesWithDefaultWordPattern = new Set([
+  "dockerfile",
+  "makefile",
+  "shellscript",
+  "bat"
+]);
+
 function newTldrHoverProvider(
   repository: TldrRepository
 ): vscode.HoverProvider {
   return {
     provideHover(document, position, token) {
-      let currentTokenRange = document.getWordRangeAtPosition(position);
+      let currentTokenRange = document.getWordRangeAtPosition(
+        position,
+        // Use our own word pattern in place of the default
+        languagesWithDefaultWordPattern.has(document.languageId)
+          ? defaultWordRegExpWithoutHyphenSeparator
+          : undefined
+      );
       if (currentTokenRange !== undefined && currentTokenRange.isSingleLine) {
         let currentToken = document.getText(currentTokenRange);
         const pageMarkdown = repository.getMarkdown(currentToken);


### PR DESCRIPTION
e.g. `docker-compose` is now treated as a single command, not two
separate commands `docker` and `compose`